### PR TITLE
Refactor new script (with test)

### DIFF
--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -168,7 +168,7 @@ class Command(BaseCommand):
             total_taxable_amount_with_tax_amount=Sum('mg_fee'),
             total_tax_amount=Sum('eb_tax'),
             payment_transactions_count=Count('event'),
-        )
+        ).iterator()
 
         for result in query_results:
             payment_option = {

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -94,7 +94,7 @@ class Command(BaseCommand):
 
         super(Command, self).__init__(*args, **kwargs)
 
-    def localice_date(self, country_code, date):
+    def localize_date(self, country_code, date):
         event_timezone = pytz.country_timezones(country_code)[0]
         return dt(
             year=date.year,
@@ -134,11 +134,11 @@ class Command(BaseCommand):
         self.logger.info("end: {}".format(self.period_end))
 
         # If the country is not specified, 'AR' will be set
-        localize_start_date = self.localice_date(
+        localize_start_date = self.localize_date(
             self.declarable_tax_receipt_countries[0],
             self.period_start
         )
-        localize_end_date = self.localice_date(
+        localize_end_date = self.localize_date(
             self.declarable_tax_receipt_countries[0],
             self.period_end
         )

--- a/invoicing_app/management/commands/generate_tax_receipts_old.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_old.py
@@ -111,10 +111,6 @@ class Command(BaseCommand):
         self.period_start = prev_month
         self.period_end = curr_month
 
-        if options['test']:
-            self.test = True
-            self.start_timer = default_timer()
-
         if options['quiet']:
             self.logger = logging.getLogger('null')
 
@@ -191,8 +187,14 @@ class Command(BaseCommand):
         )
 
     def generate_tax_receipt_event(self, payment_option, event):
-        localize_start_date = str(dt(2020, 03, 01, 0, 0))
-        localize_end_date = str(dt(2020, 04, 01, 0, 0))
+        localize_start_date = self.localice_date(
+            payment_option.epp_country,
+            self.period_start
+        )
+        localize_end_date = self.localice_date(
+            payment_option.epp_country,
+            self.period_end
+        )
 
         tax_receipt_orders = Order.objects.filter(
             status=100,

--- a/invoicing_app/management/commands/generate_tax_receipts_old.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_old.py
@@ -13,8 +13,6 @@ from invoicing import settings
 
 from invoicing_app.models import PaymentOptions, Event, Order
 
-from timeit import default_timer
-
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
 
@@ -177,7 +175,7 @@ class Command(BaseCommand):
             except Exception as e:
                 raise self._log_exception(e)
 
-    def localice_date(self, country_code, date):
+    def localize_date(self, country_code, date):
         event_timezone = pytz.country_timezones(country_code)[0]
         return dt(
             year=date.year,
@@ -187,11 +185,11 @@ class Command(BaseCommand):
         )
 
     def generate_tax_receipt_event(self, payment_option, event):
-        localize_start_date = self.localice_date(
+        localize_start_date = self.localize_date(
             payment_option.epp_country,
             self.period_start
         )
-        localize_end_date = self.localice_date(
+        localize_end_date = self.localize_date(
             payment_option.epp_country,
             self.period_end
         )

--- a/invoicing_app/tests/tests.py
+++ b/invoicing_app/tests/tests.py
@@ -165,10 +165,10 @@ class TestScriptGenerateTaxReceiptsOld(TestCase):
             "<type 'dict'>"
         )
 
-    def test_localice_date_old(self):
+    def test_localize_date_old(self):
         my_date = dt(2020, 4, 11, 0, 0)
         self.assertEqual(
-            str(self.my_command.localice_date('AR', my_date)),
+            str(self.my_command.localize_date('AR', my_date)),
             "2020-04-11 00:00:00-03:54"
         )
 


### PR DESCRIPTION
In this PR, the new script is refactorized, deleting the unused comments and imports. The method "localice_date" is added (so the dates aren't harcoded anymore). Also the country logic in the new sript is modified: when you don't specify the country, the script runs for AR and BR with the AR's timezone, and if you do specify the country, the script runs for that country in his timezone. 
Also, the tests for the old script, were re-used for the new script. In some unittest was added factory boy. 