### PR TITLE
Parent child solution

### DIFF
--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -98,6 +98,7 @@ class Command(BaseCommand):
         self.event_id = None
         self.user_id = None
         self.sentry = logging.getLogger('sentry')
+        self.parent_payment_options = {}
 
         super(Command, self).__init__(*args, **kwargs)
 
@@ -190,7 +191,6 @@ class Command(BaseCommand):
         for result in query_results:
             if result['event__event_parent']:
                 if options['use_po_dict']:
-                    self.parent_payment_options = {}
                     parent_payment_options = self.get_parent_payment_options_dict(result['event__event_parent'])
                 else:
                     parent_payment_options = self.search_parent_payment_options(result['event__event_parent'])

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -11,7 +11,7 @@ from dateutil.relativedelta import relativedelta
 
 from invoicing import settings
 
-from invoicing_app.models import PaymentOptions, Event, Order
+from invoicing_app.models import PaymentOptions, Order
 
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 
@@ -84,6 +84,13 @@ class Command(BaseCommand):
             default=False,
             help='specific country to process (like AR or BR)',
         ),
+        make_option(
+            '--podict',
+            dest="use_po_dict",
+            default=True,
+            help='flag to use or not a dict'
+                 ' for cache the result of payment options of parents events',
+        ),
     )
 
     def __init__(self, *args, **kwargs):
@@ -91,6 +98,7 @@ class Command(BaseCommand):
         self.event_id = None
         self.user_id = None
         self.sentry = logging.getLogger('sentry')
+        self.parent_payment_options = {}
 
         super(Command, self).__init__(*args, **kwargs)
 
@@ -155,8 +163,9 @@ class Command(BaseCommand):
         ).values(
             'event_id',
             'event__user_id',
-            'event___paymentoptions__epp_country',
+            'event__event_parent',
             'event__currency',
+            'event___paymentoptions__epp_country',
             'event___paymentoptions__epp_name_on_account',
             'event___paymentoptions__epp_address1',
             'event___paymentoptions__epp_address2',
@@ -171,6 +180,20 @@ class Command(BaseCommand):
         ).iterator()
 
         for result in query_results:
+            if result['event__event_parent']:
+                if options['use_po_dict']:
+                    parent_payment_options = self.get_parent_payment_options_dict(result['event__event_parent'])
+                else:
+                    parent_payment_options = self.search_parent_payment_options(result['event__event_parent'])
+
+                result['event___paymentoptions__epp_country'] = parent_payment_options['epp_country']
+                result['event___paymentoptions__epp_name_on_account'] = parent_payment_options['epp_name_on_account']
+                result['event___paymentoptions__epp_address1'] = parent_payment_options['epp_address1']
+                result['event___paymentoptions__epp_address2'] = parent_payment_options['epp_address2']
+                result['event___paymentoptions__epp_zip'] = parent_payment_options['epp_zip']
+                result['event___paymentoptions__epp_city'] = parent_payment_options['epp_city']
+                result['event___paymentoptions__epp_state'] = parent_payment_options['epp_state']
+
             payment_option = {
                 'epp_country': result['event___paymentoptions__epp_country'],
                 'epp_name_on_account': result['event___paymentoptions__epp_name_on_account'],
@@ -240,8 +263,8 @@ class Command(BaseCommand):
         if not EB_TAX_INFO:
             raise Exception('Cannot find EVENTBRITE_TAX_INFORMATION in settings')
         total_taxable_amount = (
-            tax_receipt_orders['total_taxable_amount_with_tax_amount'] -
-            tax_receipt_orders['total_tax_amount']
+                tax_receipt_orders['total_taxable_amount_with_tax_amount'] -
+                tax_receipt_orders['total_tax_amount']
         )
         orders_kwargs = {
             'tax_receipt': {
@@ -300,3 +323,26 @@ class Command(BaseCommand):
 
     def call_service(self, orders_kwargs):
         pass
+
+    def get_parent_payment_options_dict(self, event_id):
+        if event_id not in self.parent_payment_options:
+            parent_payment_options = self.search_parent_payment_options(event_id)
+
+            self.parent_payment_options[event_id] = parent_payment_options
+
+        else:
+            print self.parent_payment_options
+            parent_payment_options = self.parent_payment_options[event_id]
+
+        return parent_payment_options
+
+    def search_parent_payment_options(self, event_id):
+        return PaymentOptions.objects.filter(event=event_id).values(
+            'epp_country',
+            'epp_name_on_account',
+            'epp_address1',
+            'epp_address2',
+            'epp_zip',
+            'epp_city',
+            'epp_state',
+        )[0]

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -98,7 +98,6 @@ class Command(BaseCommand):
         self.event_id = None
         self.user_id = None
         self.sentry = logging.getLogger('sentry')
-        self.parent_payment_options = {}
 
         super(Command, self).__init__(*args, **kwargs)
 
@@ -191,6 +190,7 @@ class Command(BaseCommand):
         for result in query_results:
             if result['event__event_parent']:
                 if options['use_po_dict']:
+                    self.parent_payment_options = {}
                     parent_payment_options = self.get_parent_payment_options_dict(result['event__event_parent'])
                 else:
                     parent_payment_options = self.search_parent_payment_options(result['event__event_parent'])

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -272,8 +272,8 @@ class Command(BaseCommand):
         if not EB_TAX_INFO:
             raise Exception('Cannot find EVENTBRITE_TAX_INFORMATION in settings')
         total_taxable_amount = (
-                tax_receipt_orders['total_taxable_amount_with_tax_amount'] -
-                tax_receipt_orders['total_tax_amount']
+            tax_receipt_orders['total_taxable_amount_with_tax_amount'] -
+            tax_receipt_orders['total_tax_amount']
         )
         orders_kwargs = {
             'tax_receipt': {

--- a/invoicing_app/tests/tests.py
+++ b/invoicing_app/tests/tests.py
@@ -76,6 +76,7 @@ class TestScriptGenerateTaxReceiptsOldAndNew(TestCase):
             'country': None,
             'no_color': False,
             'logging': False,
+            'use_po_dict': False,
         }
         self.my_command.handle(**options)
         self.my_command_new.handle(**options)
@@ -269,6 +270,7 @@ class TestIntegration(TestCase):
             'country': 'AR',
             'logging': False,
             'test': False,
+            'use_po_dict': False,
         }
         self.my_command = CommandOld()
         self.my_command_new = CommandNew()
@@ -365,166 +367,37 @@ class TestIntegration(TestCase):
         )
 
     @patch(
-        'invoicing_app.management.commands.generate_tax_receipts_new.Command.call_service',
-    )
-    @patch(
         'invoicing_app.management.commands.generate_tax_receipts_old.Command.call_service',
     )
-    def test_generate_tax_receipts_w_o_oudate(self, patch_call, patch_call_new):
-        my_user_3 = UserFactory.build(
-            username='user_2'
-        )
-        my_user_3.save()
-
-        my_event_3 = EventFactory.build(
-            user=my_user_3
-        )
-        my_event_3.save()
-
-        my_pay_opt_3 = PaymentOptionsFactory.build(
-            event=my_event_3,
-        )
-        my_pay_opt_3.save()
-
-        # Set the mg_fee in 11.0 to see that the element that goes to the service isn't this
-        my_order_3 = OrderFactory.build(
-            event=my_event_3,
-            mg_fee=11.0,
-            pp_date=str(dt(2020, 07, 10, 0, 0))
-        )
-        my_order_3.save()
-
-        self.my_command.handle(**self.options)
-        self.my_command_new.handle(**self.options)
-
-        # Expected is 400 because mg_fee is 5.1 and eb_tax = 1.1
-        expected_tot_tax_amount = 400
-        call_once = 1
-
-        self.assertEqual(
-            patch_call.call_count,
-            call_once
-        )
-        self.assertEqual(
-            patch_call_new.call_count,
-            call_once
-        )
-        self.assertEqual(
-            patch_call.call_args[0][0]['tax_receipt']['total_taxable_amount']['value'],
-            expected_tot_tax_amount
-        )
-        self.assertEqual(
-            patch_call_new.call_args[0][0]['tax_receipt']['total_taxable_amount']['value'],
-            expected_tot_tax_amount
-        )
-
     @patch(
         'invoicing_app.management.commands.generate_tax_receipts_new.Command.call_service',
     )
-    @patch(
-        'invoicing_app.management.commands.generate_tax_receipts_old.Command.call_service',
-    )
-    def test_generate_tax_receipts_w_2_calls(self, patch_call, patch_call_new):
-        my_user_4 = UserFactory.build(
-            username='user_2'
-        )
-        my_user_4.save()
+    def test_generate_tax_with_child(self, call_new, call_old):
+        self.my_event.is_series_parent = True
+        self.my_event.save()
 
-        my_event_4 = EventFactory.build(
-            user=my_user_4
+        child_event = EventFactory.build(
+            user=self.my_event.user,
+            event_parent=self.my_event,
+            event_name='Child'
         )
-        my_event_4.save()
+        child_event.save()
 
-        my_pay_opt_4 = PaymentOptionsFactory.build(
-            event=my_event_4,
+        child_payment_options = PaymentOptionsFactory.build(
+            event=child_event
         )
-        my_pay_opt_4.save()
+        child_payment_options.save()
 
-        # Set the mg_fee in 11.0 to see that the element that goes to the service is this
-        my_order_4 = OrderFactory.build(
-            event=my_event_4,
-            mg_fee=11.0,
-        )
-        my_order_4.save()
+        self.my_order.event = child_event
+        self.my_order.save()
 
-        self.my_command.handle(**self.options)
+        self.options['event_id'] = child_event.id
         self.my_command_new.handle(**self.options)
-
-        # Expected is 400 because mg_fee is 11.0 and eb_tax = 1.1
-        expected_tot_tax_amount = 990
-        call_twice = 2
-
-        self.assertEqual(
-            patch_call.call_count,
-            call_twice
-        )
-        self.assertEqual(
-            patch_call_new.call_count,
-            call_twice
-        )
-        self.assertEqual(
-            patch_call.call_args[0][0]['tax_receipt']['total_taxable_amount']['value'],
-            expected_tot_tax_amount
-        )
-        self.assertEqual(
-            patch_call_new.call_args[0][0]['tax_receipt']['total_taxable_amount']['value'],
-            expected_tot_tax_amount
-        )
-
-    @patch(
-        'invoicing_app.management.commands.generate_tax_receipts_old.Command.call_service',
-    )
-    def test_generate_tax_with_child(self, patch_call):
-        my_user_5 = UserFactory.build(
-            username='user_2'
-        )
-        my_user_5.save()
-
-        my_event_5 = EventFactory.build(
-            user=my_user_5,
-            is_series_parent=True
-        )
-        my_event_5.save()
-
-        my_pay_opt_5 = PaymentOptionsFactory.build(
-            event=my_event_5
-        )
-        my_pay_opt_5.save()
-
-        # Set the mg_fee in 11.0 to see that the element that goes to the service isn't this
-        my_order_5 = OrderFactory.build(
-            event=my_event_5,
-            mg_fee=11.0,
-        )
-        my_order_5.save()
-
-        my_user_6 = UserFactory.build(
-            username='user_3'
-        )
-        my_user_6.save()
-
-        my_event_6 = EventFactory.build(
-            user=my_user_6,
-            event_parent=my_event_5
-        )
-        my_event_6.save()
-
-        my_pay_opt_6 = my_pay_opt_5
-        my_pay_opt_6.save()
-        # Set the mg_fee in 14.0 to see that the element that goes to the service is this
-        my_order_6 = OrderFactory.build(
-            event=my_event_6,
-            mg_fee=14.0,
-        )
-        my_order_6.save()
-
-        call_twice = 2
-
+        self.options['event_id'] = self.my_event.id
         self.my_command.handle(**self.options)
-
         self.assertEqual(
-            patch_call.call_count,
-            call_twice
+            call_new.call_args[0][0],
+            call_old.call_args[0][0]
         )
 
     @patch(


### PR DESCRIPTION
With this PR we add a solution for generate tax_receipts when an event have childs events.
Now if we detect an event that have a parent, we go to the database to search the paymentoptions of the parent for generate the expected output for the service, we add the test for this. 