### PR TITLE
Eda 780 script to update incomplete tax receipts

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,6 +10,7 @@ omit =
     invoicing_app/models.py
     invoicing_app/management/commands/generate_tax_receipts_old.py
     invoicing_app/management/commands/update_incomplete_tax_receipts.py
+    invoicing_app/management/commands/compare_generate.py
     invoicing_app/management/commands/create_dummy_data.py
     invoicing/*
     manage.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,7 @@ omit =
     invoicing_app/admin.py
     invoicing_app/models.py
     invoicing_app/management/commands/generate_tax_receipts_old.py
+    invoicing_app/management/commands/update_incomplete_tax_receipts.py
     invoicing_app/management/commands/create_dummy_data.py
     invoicing/*
     manage.py

--- a/invoicing_app/management/commands/compare_generate.py
+++ b/invoicing_app/management/commands/compare_generate.py
@@ -1,0 +1,70 @@
+from django.core.management.base import BaseCommand
+from optparse import make_option
+from invoicing_app.management.commands.generate_tax_receipts_old import Command as CommandOld
+from invoicing_app.management.commands.generate_tax_receipts_new import Command as CommandNew
+
+class Command(BaseCommand):
+    help = ('Generate end of month tax receipts')
+
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--date',
+            dest='today_date',
+            type='string',
+            help='Force a specific date: YYYY-MM-DD format',
+        ),
+        make_option(
+            '--country',
+            dest="country",
+            default=False,
+            help='specific country to process (like AR or BR)',
+        ),
+        make_option(
+            '--dry_run',
+            action="store_true",
+            dest='dry_run',
+            default=False,
+            help='If set, nothing will be written to DB tables.',
+        ),
+        make_option(
+            '--logging',
+            action="store_true",
+            dest="logging",
+            default=False,
+            help='Enable logger in console',
+        ),
+    )
+
+    def handle(self, *args, **options):
+        options_to_commands = {
+            'user_id': None,
+            'dry_run': options['dry_run'],
+            'settings': None,
+            'event_id': None,
+            'pythonpath': None,
+            'verbosity': 1,
+            'traceback': False,
+            'quiet': False,
+            'today_date': options['today_date'],
+            'no_color': False,
+            'country': options['country'],
+            'logging': options['logging'],
+            'compare': True
+        }
+
+        self.my_command = CommandOld()
+        self.my_command_new = CommandNew()
+
+        self.my_command.handle(**options_to_commands)
+        dict_old = self.my_command.get_dict_return()
+        print 'OLD SCRIPT'
+        print len(dict_old)
+        self.my_command_new.handle(**options_to_commands)
+        dict_new = self.my_command_new.get_dict_return()
+        print 'NEW SCRIPT'
+        print len(dict_new)
+
+        if dict_new == dict_old:
+            print 'igual'
+        else:
+            print 'diferente'

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -33,21 +33,14 @@ class Command(BaseCommand):
         This is a temporary process that retrieve order information of Brazil events
         for generate tax receipts.
         This process will be redo at hadoop (Oozie+Hive).
-
         djmanage generate_tax_receipts --settings=settings.configuration
-
         for event:
         djmanage generate_tax_receipts --event=18388067 --settings=settings.configuration
-
         for user:
         djmanage generate_tax_receipts --user=150335768 --settings=settings.configuration
-
         use --logging to enable logger in console
-
         use --dry_run to test the command but don't update any DB or call any service
-
         use --country to process an specific country
-
     """
     help = ('Generate end of month tax receipts')
 
@@ -90,20 +83,12 @@ class Command(BaseCommand):
             default=False,
             help='specific country to process (like AR or BR)',
         ),
-        make_option(
-            '--compare',
-            dest="compare",
-            default=False,
-            help='flag to return dict for comparative',
-        ),
     )
 
     def __init__(self, *args, **kwargs):
-        self.count = 0
         self.logger = logging.getLogger('financial_transactions')
         self.event_id = None
         self.user_id = None
-        self.dict_return = {}
         self.sentry = logging.getLogger('sentry')
         self.query = '''
                     SELECT
@@ -178,8 +163,6 @@ class Command(BaseCommand):
         if options['logging']:
             self.enable_logging()
 
-        self.compare = options['compare']
-
         if options['event_id']:
             self.event_id = options['event_id']
             self.query = self.query.replace(
@@ -225,11 +208,6 @@ class Command(BaseCommand):
         self.get_and_iterate_child_events(query_options)
         self.logger.info("------End Generation new tax receipts------")
         self.logger.info("------Ending generate tax receipts------")
-        print self.count
-
-    def get_dict_return(self):
-        if self.compare:
-            return self.dict_return
 
     def _log_exception(self, e, event_id=None, quiet=False):
         message = 'Error in generate_tax_receipts, event: {} , details: {}, dry_run: {} '.format(
@@ -493,9 +471,7 @@ class Command(BaseCommand):
         self.logger.addHandler(console)
 
     def call_service(self, orders_kwargs):
-        if self.compare:
-            self.dict_return.update({orders_kwargs['tax_receipt']['event_id']: orders_kwargs})
-        self.count += 1
+        print(orders_kwargs)
 
     def get_epp_tax_identifier_type(self, epp_country, epp_tax_identifier):
         if not self.dry_run:

--- a/invoicing_app/management/commands/generate_tax_receipts_old.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_old.py
@@ -84,6 +84,12 @@ class Command(BaseCommand):
             default=False,
             help='specific country to process (like AR or BR)',
         ),
+        make_option(
+            '--compare',
+            dest="compare",
+            default=False,
+            help='flag to return dict for comparative',
+        ),
     )
 
     def __init__(self, *args, **kwargs):
@@ -91,7 +97,8 @@ class Command(BaseCommand):
         self.event_id = None
         self.user_id = None
         self.sentry = logging.getLogger('sentry')
-
+        self.count = 0
+        self.dict_return = {}
         super(Command, self).__init__(*args, **kwargs)
 
     def handle(self, **options):
@@ -103,6 +110,8 @@ class Command(BaseCommand):
                 raise CommandError("Date is not matching format YYYY-MM-DD")
         else:
             today = dt.today()
+
+        self.compare = options['compare']
 
         curr_month = dt(today.year, today.month, 1)
         prev_month = curr_month - relativedelta(months=1)
@@ -140,6 +149,7 @@ class Command(BaseCommand):
         self.select_declarable_orders()
         self.logger.info("------End Generation new tax receipts------")
         self.logger.info("------Ending generate tax receipts------")
+        print self.count
 
     def select_declarable_orders(self):
         try:
@@ -173,7 +183,7 @@ class Command(BaseCommand):
                     self.generate_tax_receipt_event(payment_option, payment_option.event)
 
             except Exception as e:
-                raise self._log_exception(e)
+                print e.message
 
     def localize_date(self, country_code, date):
         event_timezone = pytz.country_timezones(country_code)[0]
@@ -332,5 +342,10 @@ class Command(BaseCommand):
         else:
             self.call_service(orders_kwargs)
 
+    def get_dict_return(self):
+        return self.dict_return
+
     def call_service(self, orders_kwargs):
-        pass
+        self.count += 1
+        if self.compare:
+            self.dict_return.update({orders_kwargs['tax_receipt']['event_id']: orders_kwargs})

--- a/invoicing_app/management/commands/update_incomplete_tax_receipts.py
+++ b/invoicing_app/management/commands/update_incomplete_tax_receipts.py
@@ -1,0 +1,105 @@
+from django.core.management.base import BaseCommand, CommandError
+from optparse import make_option
+import logging
+from django.db import connections
+from invoicing_app.models import PaymentOptions, Event, TaxReceipt
+
+
+class Command(BaseCommand):
+
+    help = ('Change status of the tax receipts that have every requirement from INCOMPLETE to PENDING')
+
+    def __init__(self, *args, **kwargs):
+        self.tax_receipts = []
+
+        base_requirements = (
+            "recipient_name",
+            "recipient_address",
+            "recipient_tax_identifier_number",
+        )
+        self.tax_to_po_requirement_dict = {
+            "recipient_name": "epp_name_on_account",
+            "recipient_address": "epp_address1",
+            "recipient_tax_identifier_number": "epp_tax_identifier",
+            "recipient_postal_code": "epp_zip",
+            "recipient_city": "epp_city",
+            "tax_regime_type_id": "",
+        }
+        self.arg_requirements = base_requirements# + ("tax_regime_type_id",)
+        self.br_requirements = base_requirements + ("recipient_postal_code",)
+        self.CPF_CHAR_COUNT_LIMIT = 11
+        super(Command, self).__init__(*args, **kwargs)
+
+    def handle(self, **options):
+        print("----Finding tax receipts that meet requiremente criteria----")
+        self.find_incomplete_tax_receipts()
+        self.update_tax_receipts_that_met_requirements()
+        print("----Updated process completed.----")
+
+    def find_incomplete_tax_receipts(self):
+        self.tax_receipts = TaxReceipt.objects.using('billing_local')\
+            .filter(status_id=TaxReceiptStatuses.get_id_from_name("INCOMPLETE"),
+                    reporting_country_code__in=['AR', 'BR']).iterator()
+
+    def update_tax_receipts_that_met_requirements(self):
+        for tax_receipt in self.tax_receipts:
+            po = PaymentOptions.objects.using('default').get(event=tax_receipt.event_id)
+            if tax_receipt.reporting_country_code == 'AR':
+                self.__check_ARG_requirements(tax_receipt, po)
+            else:
+                self.__check_BR_requirements(tax_receipt, po)
+
+    def __check_ARG_requirements(self, tax_receipt, payment_option):
+        # IF ONE FIELD FAILS CHECK REQUIREMENTS, WE CANT CHANGE TO 'PENDING' STATUS
+        # SO ITS POINTLESS TO KEEP CHECKING REST OF FIELDS.
+        for requirement in self.arg_requirements:
+            po_attribute = getattr(payment_option, str(self.tax_to_po_requirement_dict.get(requirement)), '')
+            if self.__check_single_requirement(po_attribute):
+                setattr(tax_receipt, requirement, po_attribute)
+            else:
+                return
+        self.__update_tax_receipt(tax_receipt)
+
+    def __check_BR_requirements(self, tax_receipt, payment_option):
+        # CHECK IF BR TAX AUTHORITY IS CPNJ OR CPF, BECAUSE THEY USE DIFFERENT REQUIREMENTS.
+        if self.__get_epp_tax_identifier_type(payment_option.epp_tax_identifier) == 'CNPJ':
+            for requirement in self.br_requirements + ('recipient_city',):
+                po_attribute = getattr(payment_option, str(self.tax_to_po_requirement_dict.get(requirement)), '')
+                if self.__check_single_requirement(po_attribute):
+                    setattr(tax_receipt, requirement, po_attribute)
+                else:
+                    return
+            self.__update_tax_receipt(tax_receipt)
+
+        elif self.__get_epp_tax_identifier_type(payment_option.epp_tax_identifier) == 'CPF':
+            for requirement in self.br_requirements:
+                po_attribute = getattr(payment_option, str(self.tax_to_po_requirement_dict.get(requirement)), '')
+                if self.__check_single_requirement(po_attribute):
+                    setattr(tax_receipt, requirement, po_attribute)
+                else:
+                    return
+            self.__update_tax_receipt(tax_receipt)
+
+    def __check_single_requirement(self, po_attr):
+        return po_attr == ''
+
+    def __update_tax_receipt(self, tax_receipt):
+        tax_receipt.status_id = TaxReceiptStatuses.get_id_from_name("PENDING")
+        tax_receipt.save(using='billing_local', force_update=True)
+
+
+    def __get_epp_tax_identifier_type(self, epp_tax_identifier): #
+        if len(epp_tax_identifier) > self.CPF_CHAR_COUNT_LIMIT:
+            return 'CNPJ'
+        else:
+            return 'CPF'
+        return ''
+
+
+class TaxReceiptStatuses:
+    @staticmethod
+    def get_id_from_name(string):
+        if string is "INCOMPLETE":
+            return 1
+        elif string is 'PENDING':
+            return 2


### PR DESCRIPTION
This scripts intends to update Tax Receipts that have status of INCOMPLETE when it checks that its associated Payment Option has all the necessary information. If this is the case, update its fields and change status to PENDING, this is necessary to declare them to their respective Tax Authority.