### PR TITLE
Eda 1045 refactor generation

### DIFF
--- a/invoicing_app/circuitbreaker.py
+++ b/invoicing_app/circuitbreaker.py
@@ -83,7 +83,7 @@ class CircuitBreaker(object):
         -Circuit state: {},
         -Circuit timeout: {}s,
         -Circuit threshold: {},
-        -Expected exception: {}  
+        -Expected exception: {}
         '''.format(self._external_service.__name__.capitalize(),
                    0 if not self._last_failure else self._last_failure,
                    self.show_state,

--- a/invoicing_app/management/commands/generate_tax_receipts.py
+++ b/invoicing_app/management/commands/generate_tax_receipts.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
                         SUM(`Orders`.`gross`) AS `base_amount`
                     FROM `Orders`
                         INNER JOIN `Events` ON (`Orders`.`event` = `Events`.`id` )
-                        INNER JOIN `Payment_Options` ON PARENT_CHILD_MASK
+                        INNER JOIN `Payment_Options` ON {parent_child_mask}
                     WHERE (
                         `Orders`.`status` = %(status_query)s AND
                         `Orders`.`pp_date` <= %(localize_end_date_query)s AND
@@ -123,7 +123,7 @@ class Command(BaseCommand):
                         `Orders`.`pp_date` >= %(localize_start_date_query)s AND
                         `Payment_Options`.`accept_eventbrite` = 1 AND
                         `Payment_Options`.`epp_country` = %(declarable_tax_receipt_countries_query)s
-                        CONDITION_MASK
+                        {condition_mask}
                     )
                     GROUP BY
                         `event_id`
@@ -174,8 +174,7 @@ class Command(BaseCommand):
             self.conditional_mask = 'AND `Events`.`uid` = ' + str(self.user_id)
 
         # The self.conditional_mask is put into the query
-        self.query = self.query.replace('CONDITION_MASK', '{}')
-        self.query = self.query.format(self.conditional_mask)
+        self.query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask='{parent_child_mask}')
 
         localize_start_date = self.localize_date(
             self.declarable_tax_receipt_countries,
@@ -243,8 +242,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_no_series_events(self, query_options):
         parent_mask = '(`Events`.`id` = `Payment_Options`.`event`)'
-        query = self.query.replace('PARENT_CHILD_MASK', '{}')
-        query = query.format(parent_mask)
+        query = self.query.format(parent_child_mask=parent_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,
@@ -254,8 +252,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_child_events(self, query_options):
         child_mask = '(`Events`.`event_parent` = `Payment_Options`.`event`)'
-        query = self.query.replace('PARENT_CHILD_MASK', '{}')
-        query = query.format(child_mask)
+        query = self.query.format(parent_child_mask=child_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,

--- a/invoicing_app/management/commands/generate_tax_receipts.py
+++ b/invoicing_app/management/commands/generate_tax_receipts.py
@@ -92,6 +92,7 @@ class Command(BaseCommand):
         self.event_id = None
         self.user_id = None
         self.sentry = logging.getLogger('sentry')
+        self.conditional_mask = ''
         self.query = '''
                     SELECT
                         `Orders`.`event` as `event_id`,

--- a/invoicing_app/management/commands/generate_tax_receipts.py
+++ b/invoicing_app/management/commands/generate_tax_receipts.py
@@ -173,9 +173,6 @@ class Command(BaseCommand):
             self.user_id = options['user_id']
             self.conditional_mask = 'AND `Events`.`uid` = {}'.format(self.user_id)
 
-        # The self.conditional_mask is put into the query
-        self.query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask='{parent_child_mask}')
-
         localize_start_date = self.localize_date(
             self.declarable_tax_receipt_countries,
             self.period_start
@@ -242,7 +239,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_no_series_events(self, query_options):
         parent_mask = '(`Events`.`id` = `Payment_Options`.`event`)'
-        query = self.query.format(parent_child_mask=parent_mask)
+        query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask=parent_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,
@@ -252,7 +249,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_child_events(self, query_options):
         child_mask = '(`Events`.`event_parent` = `Payment_Options`.`event`)'
-        query = self.query.format(parent_child_mask=child_mask)
+        query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask=child_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,

--- a/invoicing_app/management/commands/generate_tax_receipts.py
+++ b/invoicing_app/management/commands/generate_tax_receipts.py
@@ -167,11 +167,11 @@ class Command(BaseCommand):
 
         if options['event_id']:
             self.event_id = options['event_id']
-            self.conditional_mask = 'AND `Events`.`id` = ' + str(self.event_id)
+            self.conditional_mask = 'AND `Events`.`id` = {}'.format(self.event_id)
 
         if options['user_id']:
             self.user_id = options['user_id']
-            self.conditional_mask = 'AND `Events`.`uid` = ' + str(self.user_id)
+            self.conditional_mask = 'AND `Events`.`uid` = {}'.format(self.user_id)
 
         # The self.conditional_mask is put into the query
         self.query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask='{parent_child_mask}')

--- a/invoicing_app/management/commands/generate_tax_receipts.py
+++ b/invoicing_app/management/commands/generate_tax_receipts.py
@@ -166,24 +166,15 @@ class Command(BaseCommand):
 
         if options['event_id']:
             self.event_id = options['event_id']
-            self.query = self.query.replace(
-                'CONDITION_MASK',
-                'AND `Events`.`id` = ' + str(self.event_id)
-            )
+            self.conditional_mask = 'AND `Events`.`id` = ' + str(self.event_id)
 
         if options['user_id']:
             self.user_id = options['user_id']
-            self.query = self.query.replace(
-                'CONDITION_MASK',
-                'AND `Events`.`uid` = ' + str(self.user_id)
-            )
+            self.conditional_mask = 'AND `Events`.`uid` = ' + str(self.user_id)
 
-        # If there isn't condition, remove the CONDITION MASK from the query
-        if (not options['user_id']) and (not options['event_id']):
-            self.query = self.query.replace(
-                'CONDITION_MASK',
-                ''
-            )
+        # The self.conditional_mask is put into the query
+        self.query = self.query.replace('CONDITION_MASK', '{}')
+        self.query = self.query.format(self.conditional_mask)
 
         localize_start_date = self.localize_date(
             self.declarable_tax_receipt_countries,
@@ -250,53 +241,33 @@ class Command(BaseCommand):
         ).astimezone(tzinfo.get_default_tzinfo()).replace(tzinfo=None)
 
     def get_and_iterate_no_series_events(self, query_options):
-        # Replace of PARENT_CHILD_MASK for the no-series condition in INNER JOIN
-        self.query = self.query.replace(
-            'PARENT_CHILD_MASK',
-            '(`Events`.`id` = `Payment_Options`.`event`)'
-        )
-        query_results = self.get_query_results(query_options)
+        parent_mask = '(`Events`.`id` = `Payment_Options`.`event`)'
+        query = self.query.replace('PARENT_CHILD_MASK', '{}')
+        query = query.format(parent_mask)
+        query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,
             query_options['localize_start_date_query'],
             query_options['localize_end_date_query'],
-        )
-        # Undo the replacing of PARENT_CHILD_MASK for the child events
-        self.query = self.query.replace(
-            '(`Events`.`id` = `Payment_Options`.`event`)',
-            'PARENT_CHILD_MASK'
         )
 
     def get_and_iterate_child_events(self, query_options):
-        self.query = self.query.replace(
-            'PARENT_CHILD_MASK',
-            '(`Events`.`event_parent` = `Payment_Options`.`event`)'
-        )
-        # Can't use a mask here, so replace a entire WHERE condition
-        self.query = self.query.replace(
-            '`Payment_Options`.`accept_eventbrite` = 1 AND',
-            '`Payment_Options`.`accept_eventbrite` = 1 AND `Events`.`event_parent` IS NOT NULL AND',
-        )
-
-        query_results = self.get_query_results(query_options)
-
+        child_mask = '(`Events`.`event_parent` = `Payment_Options`.`event`)'
+        query = self.query.replace('PARENT_CHILD_MASK', '{}')
+        query = query.format(child_mask)
+        query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,
             query_options['localize_start_date_query'],
             query_options['localize_end_date_query'],
         )
 
-        self.query = self.query.replace(
-            '(`Events`.`event_parent` = `Payment_Options`.`event`)',
-            'PARENT_CHILD_MASK'
-        )
-
-    def get_query_results(self, query_options):
+    def get_query_results(self, query_options, query):
         query_results = []
 
         with connections['slave'].cursor() as cursor:
             cursor.execute(
-                self.query,
+                query,
                 query_options
             )
             response = cursor.fetchall()

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -122,7 +122,7 @@ class Command(BaseCommand):
                         SUM(`Orders`.`gross`) AS `base_amount`
                     FROM `Orders`
                         INNER JOIN `Events` ON (`Orders`.`event` = `Events`.`id` )
-                        INNER JOIN `Payment_Options` ON PARENT_CHILD_MASK
+                        INNER JOIN `Payment_Options` ON {parent_child_mask}
                     WHERE (
                         `Orders`.`status` = %(status_query)s AND
                         `Orders`.`pp_date` <= %(localize_end_date_query)s AND
@@ -132,7 +132,7 @@ class Command(BaseCommand):
                         `Orders`.`pp_date` >= %(localize_start_date_query)s AND
                         `Payment_Options`.`accept_eventbrite` = 1 AND
                         `Payment_Options`.`epp_country` = %(declarable_tax_receipt_countries_query)s
-                        CONDITION_MASK
+                        {condition_mask}
                     )
                     GROUP BY
                         `event_id`
@@ -190,8 +190,7 @@ class Command(BaseCommand):
             self.conditional_mask = 'AND `Events`.`uid` = ' + str(self.user_id)
 
         # The self.conditional_mask is put into the query
-        self.query = self.query.replace('CONDITION_MASK', '{}')
-        self.query = self.query.format(self.conditional_mask)
+        self.query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask='{parent_child_mask}')
 
         localize_start_date = self.localize_date(
             self.declarable_tax_receipt_countries,
@@ -269,8 +268,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_no_series_events(self, query_options):
         parent_mask = '(`Events`.`id` = `Payment_Options`.`event`)'
-        query = self.query.replace('PARENT_CHILD_MASK', '{}')
-        query = query.format(parent_mask)
+        query = self.query.format(parent_child_mask=parent_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,
@@ -280,8 +278,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_child_events(self, query_options):
         child_mask = '(`Events`.`event_parent` = `Payment_Options`.`event`)'
-        query = self.query.replace('PARENT_CHILD_MASK', '{}')
-        query = query.format(child_mask)
+        query = self.query.format(parent_child_mask=child_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -102,7 +102,6 @@ class Command(BaseCommand):
         self.sentry = logging.getLogger('sentry')
         self.error_cont = 0
         self.conditional_mask = ''
-        # self.parent_child_mask = ''
         self.query = '''
                     SELECT
                         `Orders`.`event` as `event_id`,

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -183,11 +183,11 @@ class Command(BaseCommand):
 
         if options['event_id']:
             self.event_id = options['event_id']
-            self.conditional_mask = 'AND `Events`.`id` = ' + str(self.event_id)
+            self.conditional_mask = 'AND `Events`.`id` = {}'.format(self.event_id)
 
         if options['user_id']:
             self.user_id = options['user_id']
-            self.conditional_mask = 'AND `Events`.`uid` = ' + str(self.user_id)
+            self.conditional_mask = 'AND `Events`.`uid` = {}'.format(self.user_id)
 
         # The self.conditional_mask is put into the query
         self.query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask='{parent_child_mask}')

--- a/invoicing_app/management/commands/generate_tax_receipts_new.py
+++ b/invoicing_app/management/commands/generate_tax_receipts_new.py
@@ -189,9 +189,6 @@ class Command(BaseCommand):
             self.user_id = options['user_id']
             self.conditional_mask = 'AND `Events`.`uid` = {}'.format(self.user_id)
 
-        # The self.conditional_mask is put into the query
-        self.query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask='{parent_child_mask}')
-
         localize_start_date = self.localize_date(
             self.declarable_tax_receipt_countries,
             self.period_start
@@ -268,7 +265,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_no_series_events(self, query_options):
         parent_mask = '(`Events`.`id` = `Payment_Options`.`event`)'
-        query = self.query.format(parent_child_mask=parent_mask)
+        query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask=parent_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,
@@ -278,7 +275,7 @@ class Command(BaseCommand):
 
     def get_and_iterate_child_events(self, query_options):
         child_mask = '(`Events`.`event_parent` = `Payment_Options`.`event`)'
-        query = self.query.format(parent_child_mask=child_mask)
+        query = self.query.format(condition_mask=self.conditional_mask, parent_child_mask=child_mask)
         query_results = self.get_query_results(query_options, query)
         self.iterate_querys_results(
             query_results,

--- a/invoicing_app/tests/tests.py
+++ b/invoicing_app/tests/tests.py
@@ -383,11 +383,11 @@ class TestScriptGenerateTaxReceiptsNew(TestCase):
             '(`Events`.`id` = `Payment_Options`.`event`)'
         )
         returns_one_element = 1
-        self.assertEqual(
-            str(type(self.my_command_new.get_query_results(
+        self.assertIsInstance(
+            self.my_command_new.get_query_results(
                 query_options_test, self.my_command_new.query
-            ))),
-            "<type 'list'>"
+            ),
+            list
         )
         self.assertEqual(
             len(self.my_command_new.get_query_results(

--- a/invoicing_app/tests/tests.py
+++ b/invoicing_app/tests/tests.py
@@ -138,10 +138,6 @@ class TestScriptGenerateTaxReceiptsOldAndNew(TestCase):
             self.my_command_new.event_id,
             self.options['event_id']
         )
-        self.assertIn(
-            'AND `Events`.`id` = {}'.format(self.options['event_id']),
-            self.my_command_new.query
-        )
 
     def test_user_id_option(self):
         self.options['user_id'] = '1'
@@ -157,11 +153,6 @@ class TestScriptGenerateTaxReceiptsOldAndNew(TestCase):
             self.my_command_new.user_id,
             self.options['user_id']
         )
-        self.assertIn(
-            'AND `Events`.`uid` = {}'.format(self.options['user_id']),
-            self.my_command_new.query
-        )
-
 
 class TestScriptGenerateTaxReceiptsOld(TestCase):
     """

--- a/invoicing_app/tests/tests.py
+++ b/invoicing_app/tests/tests.py
@@ -393,13 +393,18 @@ class TestScriptGenerateTaxReceiptsNew(TestCase):
         )
         returns_one_element = 1
         self.assertEqual(
-            str(type(self.my_command_new.get_query_results(query_options_test))),
+            str(type(self.my_command_new.get_query_results(
+                query_options_test, self.my_command_new.query
+            ))),
             "<type 'list'>"
         )
         self.assertEqual(
-            len(self.my_command_new.get_query_results(query_options_test)),
+            len(self.my_command_new.get_query_results(
+                query_options_test, self.my_command_new.query
+            )),
             returns_one_element
         )
+
 
 class TestIntegration(TestCase):
     """
@@ -773,6 +778,7 @@ class TestIntegration(TestCase):
             call_new.call_count
         )
 
+
 class TestCircuitBreaker(TestCase):
     def setUp(self):
         def division(a, b):
@@ -792,7 +798,7 @@ class TestCircuitBreaker(TestCase):
         self.assertEquals(call, 1)
 
     def test_threshold_reached_and_circuit_opens(self):
-        ## Most tests use 2 0 as *args to test faulty services because 2 / 0 raises an Exception
+        # Most tests use 2 0 as *args to test faulty services because 2 / 0 raises an Exception
         self.circuit_breaker.call_external_service(2, 0)
         self.circuit_breaker.call_external_service(2, 0)
         self.circuit_breaker.call_external_service(2, 0)
@@ -803,7 +809,7 @@ class TestCircuitBreaker(TestCase):
         self.circuit_breaker.call_external_service(2, 0)
         self.circuit_breaker.call_external_service(2, 0)
         self.circuit_breaker.call_external_service(2, 0)
-        ##Sleep time to update circuit state to HALF OPEN
+        # Sleep time to update circuit state to HALF OPEN
         sleep(2)
         self.circuit_breaker.call_external_service(2, 0)
         self.assertEquals(self.circuit_breaker.show_state, "HALF-OPEN")
@@ -816,6 +822,6 @@ class TestCircuitBreaker(TestCase):
         -Circuit state: CLOSED,
         -Circuit timeout: 1s,
         -Circuit threshold: 3,
-        -Expected exception: ZeroDivisionError  
+        -Expected exception: ZeroDivisionError
         '''
         self.assertEquals(str(self.circuit_breaker), expected_str)

--- a/invoicing_app/tests/tests.py
+++ b/invoicing_app/tests/tests.py
@@ -329,7 +329,7 @@ class TestScriptGenerateTaxReceiptsNew(TestCase):
             'status_query': 100,
         }
         self.my_command_new.query = self.my_command_new.query.replace(
-            'CONDITION_MASK',
+            '{condition_mask}',
             ''
         )
         self.my_command_new.get_and_iterate_no_series_events(query_options_test)
@@ -358,7 +358,7 @@ class TestScriptGenerateTaxReceiptsNew(TestCase):
             'status_query': 100,
         }
         self.my_command_new.query = self.my_command_new.query.replace(
-            'CONDITION_MASK',
+            '{condition_mask}',
             ''
         )
         self.my_command_new.get_and_iterate_child_events(query_options_test)
@@ -384,11 +384,11 @@ class TestScriptGenerateTaxReceiptsNew(TestCase):
             'status_query': 100,
         }
         self.my_command_new.query = self.my_command_new.query.replace(
-            'CONDITION_MASK',
+            '{condition_mask}',
             ''
         )
         self.my_command_new.query = self.my_command_new.query.replace(
-            'PARENT_CHILD_MASK',
+            '{parent_child_mask}',
             '(`Events`.`id` = `Payment_Options`.`event`)'
         )
         returns_one_element = 1


### PR DESCRIPTION
In this PR the masks in the raw query are replaced by placeholders, in generate_tax_receipts_new and generate_tax_receipts (prod).
This is for get the code cleaner. 